### PR TITLE
Use standard thread library to avoid conflict with boost's one.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ target_link_libraries(scylla_blas PUBLIC scylla_modern_cpp_driver fmt::fmt)
 set(EXEC_SRC
         src/main.cc)
 
-find_package(Boost 1.60.0 COMPONENTS system thread filesystem unit_test_framework program_options REQUIRED )
+find_package(Boost 1.60.0 COMPONENTS system filesystem unit_test_framework program_options REQUIRED )
 add_executable(scylla_blas_worker "${EXEC_SRC}")
 target_include_directories(scylla_blas_worker PUBLIC "${Boost_INCLUDE_DIRS}")
 target_link_libraries(scylla_blas_worker PUBLIC scylla_blas "${Boost_LIBRARIES}")

--- a/include/scylla_blas/utils/utils.hh
+++ b/include/scylla_blas/utils/utils.hh
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <boost/thread/thread.hpp>
+#include <thread>
 #include <chrono>
 
 namespace scylla_blas {
@@ -12,7 +12,7 @@ inline int64_t get_timestamp() {
 }
 
 inline void wait_seconds(int64_t count) {
-    boost::this_thread::sleep(boost::posix_time::seconds(count));
+    std::this_thread::sleep_for(std::chrono::seconds(count));
 }
 
 }


### PR DESCRIPTION
Also, remove boost::thread completely.

Fixes #16